### PR TITLE
configuration & performance optimized

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"math/rand/v2"
 )
 
 var ErrOutOfRange = errors.New("out of range")
@@ -15,16 +16,19 @@ type buffer struct {
 	data  []byte
 }
 
-func NewBuffer(size int32, alloc bool) *buffer {
+func NewBuffer(size int32, alloc bool, shuffleRatio float32) *buffer {
 	buf := &buffer{
 		index: 0,
 		size:  size,
 		used:  0,
-		data:  make([]byte, 0),
+		data:  nil,
 	}
 
 	if alloc {
 		buf.data = make([]byte, size)
+		if shuffleRatio > 0 {
+			buf.index = int32(float32(size) * (rand.Float32() * shuffleRatio))
+		}
 	}
 
 	return buf
@@ -33,7 +37,7 @@ func NewBuffer(size int32, alloc bool) *buffer {
 func (buf *buffer) Clear() {
 	buf.index = 0
 	buf.used = 0
-	buf.data = make([]byte, 0)
+	buf.data = nil
 }
 
 func (buf *buffer) ReAlloc() {

--- a/config.go
+++ b/config.go
@@ -3,17 +3,41 @@ package heyicache
 type Config struct {
 	// required: Name of the cache instance
 	Name string
+
 	// MaxSize is a limit for arena size in MB.
 	// Once it initialized, it cannot be changed.
 	MaxSize int32
+
+	// If close it, the cache will not allow to exceed MaxSize.
+	// default is false, means the cache can grow to MaxSize * (1 + MaxSizeBeyondRatio)
+	// we don't recommend to set it to true, because it will cause write error when segment is cleaning
+	CloseMaxSizeBeyond bool
+
+	// default is 10% if CloseMaxSizeBeyond is false, means the cache can grow to MaxSize * (1 + MaxSizeBeyondRatio)
+	// eg: MaxSize = 100MB, MaxSizeBeyondRatio = 0.1 means the cache can grow to 110MB in short time to decrease write error.
+	MaxSizeBeyondRatio float32
+
+	// If close it, the cache will NOT set the buffer start from 0~50% ramdomly
+	// it will helpful if you don't want all your buffers expired at the same time
+	// default is false
+	// we don't recommend to set it to true, because it will cause all your buffers expired at the same time at beginning
+	CloseBufferShuffle bool
+
+	// default is 30% if CloseBufferShuffle is false, means the buffer will start from 0~30% ramdomly
+	BufferShuffleRatio float32
+
 	// Custom timer
 	CustomTimer Timer
 }
 
 func DefaultConfig(name string) Config {
 	return Config{
-		Name:        name,
-		MaxSize:     minSize,
-		CustomTimer: defaultTimer{},
+		Name:               name,
+		MaxSize:            minSize,
+		CustomTimer:        defaultTimer{},
+		CloseMaxSizeBeyond: defaultCloseMaxSizeBeyond,
+		MaxSizeBeyondRatio: defaultMaxSizeBeyondRatio,
+		CloseBufferShuffle: defaultCloseBufferShuffle,
+		BufferShuffleRatio: defaultBufferShuffleRatio,
 	}
 }

--- a/lease_ctx.go
+++ b/lease_ctx.go
@@ -3,19 +3,31 @@ package heyicache
 import (
 	"context"
 	"fmt"
+	"sync"
 )
 
 var (
 	ErrNilLeaseCtx = fmt.Errorf("lease context is nil")
 	leaseCtxKey    = "arena_cache_lease"
+	keepsPool      = newKeepsPool()
+	keepsNew       = [segCount][versionCount]int64{}
 )
+
+// 对象池用于复用 keeps 数组，减少内存分配
+func newKeepsPool() *sync.Pool {
+	return &sync.Pool{
+		New: func() interface{} {
+			return new([segCount][versionCount]int64)
+		},
+	}
+}
 
 type LeaseCtx struct {
 	leases map[string]*Lease
 }
 
 type Lease struct {
-	keeps [segCount][versionCount]int64
+	keeps *[segCount][versionCount]int64
 	cache *Cache
 }
 
@@ -45,7 +57,7 @@ func (leaseCtx *LeaseCtx) GetLease(cache *Cache) *Lease {
 	if _, ok := leaseCtx.leases[cache.Name]; !ok {
 		leaseCtx.leases[cache.Name] = &Lease{
 			cache: cache,
-			keeps: [segCount][versionCount]int64{},
+			keeps: keepsPool.Get().(*[segCount][versionCount]int64),
 		}
 	}
 	return leaseCtx.leases[cache.Name]
@@ -60,17 +72,20 @@ func (leaseCtx *LeaseCtx) Done() {
 		if lease == nil {
 			continue
 		}
-
-		for segID, vs := range lease.keeps {
+		for segID, vs := range *(lease.keeps) {
 			for version, k := range vs {
 				if k <= 0 {
 					continue
 				}
-
 				lease.cache.locks[segID].Lock()
 				lease.cache.segments[segID].processUsed(int32(version), -k)
 				lease.cache.locks[segID].Unlock()
 			}
 		}
+		// 归还 keeps 到对象池
+		// 快速将 lease.keeps 全部置为 0，采用内存拷贝
+		*lease.keeps = keepsNew
+		keepsPool.Put(lease.keeps)
+		lease.keeps = nil
 	}
 }

--- a/segment.go
+++ b/segment.go
@@ -62,6 +62,7 @@ func (seg *segment) enough(allSize int32) bool {
 	return allSize+seg.getBuffer().index < seg.getBuffer().size
 }
 
+//go:inline
 func (seg *segment) processUsed(version int32, k int64) {
 	seg.bufs[version].used += k
 	if seg.version == version {

--- a/segment.go
+++ b/segment.go
@@ -8,6 +8,8 @@ import (
 )
 
 var ErrSegmentFull = errors.New("segment is full, please wait for automatic eviction")
+var ErrSegmentBusy = errors.New("segment is busy, please check if the beyond ratio is set too small")
+var ErrSegmentUnlucky = errors.New("segment is unlucky, please retry")
 var ErrValueTooBig = errors.New("value is too big, please use smaller value or increase cache size")
 var ErrSegmentCleaning = errors.New("segment has been expanded, re-allocate space, please retry")
 var maxLocateRetry = 3
@@ -32,19 +34,21 @@ type segment struct {
 	slotsLen          [slotCount]int32 // the length for every slot
 	slotCap           int32            // max number of entry pointers a slot can hold.
 	slotsData         []entryPtr
+	idleBuf           *int32
 }
 
-func newSegment(bufSize, segId int32, timer Timer) segment {
+func newSegment(bufSize, segId int32, idleBuf *int32, shuffleRatio float32, timer Timer) segment {
 	seg := segment{
 		bufs:      [versionCount]*buffer{},
 		segId:     segId,
 		timer:     timer,
 		slotCap:   1,
 		slotsData: make([]entryPtr, slotCount),
+		idleBuf:   idleBuf,
 	}
 
 	for i := 0; i < int(versionCount); i++ {
-		seg.bufs[i] = NewBuffer(bufSize, i == int(seg.version))
+		seg.bufs[i] = NewBuffer(bufSize, i == int(seg.version), shuffleRatio)
 	}
 
 	return seg
@@ -65,6 +69,14 @@ func (seg *segment) processUsed(version int32, k int64) {
 	}
 	if seg.bufs[version].used == 0 {
 		seg.bufs[version].Clear()
+		for {
+			// make sure success
+			idle := atomic.LoadInt32(seg.idleBuf)
+			ok := atomic.CompareAndSwapInt32(seg.idleBuf, idle, idle+1)
+			if ok {
+				break
+			}
+		}
 	}
 }
 
@@ -82,6 +94,21 @@ func (seg *segment) eviction() error {
 		// fmt.Println("eviction wait, segId", seg.segId, "version", seg.version, "used", seg.used, "tmp1Used", seg.tmp1Used, "tmp2Used", seg.tmp2Used)
 		atomic.AddInt64(&seg.totalEvictionWait, 1)
 		return ErrSegmentFull
+	}
+
+	idle := atomic.LoadInt32(seg.idleBuf)
+	if idle <= 0 {
+		// no space to allocate, return error
+		// better to expand the MaxSizeBeyondRatio
+		atomic.AddInt64(&seg.totalEvictionWait, 1)
+		return ErrSegmentBusy
+	}
+
+	ok := atomic.CompareAndSwapInt32(seg.idleBuf, idle, idle-1)
+	if !ok {
+		// someone move faster than us
+		atomic.AddInt64(&seg.totalEvictionWait, 1)
+		return ErrSegmentUnlucky
 	}
 
 	// fmt.Println("eviction done, segId", seg.segId, "version", seg.version, "used", seg.used, "tmp1Used", seg.tmp1Used, "tmp2Used", seg.tmp2Used)


### PR DESCRIPTION
1. add config: max size beyond, it allows heyicache use a little more memory to decrease the write wait time when segment is full
2. add config: buffer shuffle, it allosw heyicache init segment buffer index from 0~ratio% randomly, to avoid all the segment buffer full and expire at same time
3. expand segment count from 256 to 2048, it will decrease the expire ratio in a clean process from 1/256 to 1/2048, will make heyicahe more effective
4. use obj pool in lease Get/Done, will save lots cpu(in my server about 2~3%) in lease process
5. independent error code to make suggestion more easier to execute